### PR TITLE
Bullet formatting was lost in markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ If you are a developer interested in Homomorphic Encryption and you use a MacOS 
 The contents of this Xcode project includes the pre-determined compilation procedure and the required dependency relationships between source code modules. Typically an Xcode project contains one or more build targets, which specify the compilation procedure for the final executable or library products. This project comes complete with default build settings for HELib as well as the two external dependencies required by HELib, namely [The GNU Multiple Precision Arithmetic Library (GMP)](https://gmplib.org/) and [NTL Lib](https://www.shoup.net/ntl/) which is a number theoretic library.
 
 The targets of the project are:
-	•	Privacy Preserving Search (sample app)
-	•	helib Library
+* Privacy Preserving Search (sample app)
+* helib Library
 
 
 


### PR DESCRIPTION
Bullet formatting was lost in markdown, this patch corrects it. Thanks to Emma D. for reporting the issue. 