### PR TITLE
Default NTL Threads should be 1  (#44)

### DIFF
--- a/fhe-toolkit-macos/SampleCode/CapitalDetailViewController.mm
+++ b/fhe-toolkit-macos/SampleCode/CapitalDetailViewController.mm
@@ -58,7 +58,7 @@ unsigned long bits = 1000;
 // Number of columns of Key-Switching matrix (default = 2 or 3)
 unsigned long c = 2;
 // Size of NTL thread pool (default =1)
-unsigned long nthreads = 63;
+unsigned long nthreads = 1;
 // debug output (default no debug output)
 unsigned long debug = 0;
 


### PR DESCRIPTION
Probably a typo on CapitalDetailViewController.mm line 61
```
// Size of NTL thread pool (default =1)
unsigned long nthreads = 63;
```
Corrected to 
```
// Size of NTL thread pool (default =1)
unsigned long nthreads = 1;
```
